### PR TITLE
feat: move control flow

### DIFF
--- a/src/internal/core/index.ts
+++ b/src/internal/core/index.ts
@@ -64,10 +64,23 @@ export function f(children: Render[] = []): Render {
     return render => render.fragment(children)
 }
 
+/**
+ * Allows for conditional and list rendering with a Virtual DOM-like approach.
+ * This allows control flow customizability and cross-platform compatability, meaning the consuming API can be rendered in CSR, SSR, and SSG environments.
+ * @see when and @see each for examples.
+ * @param blocks A factory function that returns an array of blocks to be rendered to the DOM; @see block for details
+ * @returns 
+ */
 export function directive(blocks: Accessor<Block[]>): Render {
     return render => render.directive(blocks)
 }
 
+/**
+ * Adds a block to a `directive`'s blocks array
+ * @param id the block's id used to track the block
+ * @param template a factory function to render when the block is created or updated
+ * @param context a context that a block uses in the `template`
+ */
 export function block<Context>(id: string, template: (context: Accessor<Context>) => Render, context: Context): Block {
     return block => block(id, template, context)
 }

--- a/src/internal/core/index.ts
+++ b/src/internal/core/index.ts
@@ -89,13 +89,15 @@ export function when(cond: Accessor, then: Render, alt: Render = f()) {
  * Renders a list of items to the document.
  * @param ... has two properties: `items` contains the items to iterate over, and `trackBy` contains a function to track each item
  * @param renderItems a function that returns a render instruction for each item
+ * @param alt a render instruction to render when the `items` array is empty
  */
 export function each<TItem>(
     {items, trackBy = () => (_, idx) => idx}: {
         items: Accessor<TItem[]>,
         trackBy?: Accessor<(item: TItem, index: number, array: TItem[]) => any>,
     },
-    renderItems: (item: Accessor<TItem>, index: Accessor<number>, array: Accessor<TItem[]>) => Render
+    renderItems: (item: Accessor<TItem>, index: Accessor<number>, array: Accessor<TItem[]>) => Render,
+    alt: Render
 ): Render {
     const template = (context: () => {item: TItem, index: number, array: TItem[]}) => renderItems(
         () => context().item,
@@ -104,6 +106,7 @@ export function each<TItem>(
     )
     return directive(() => {
         const tb = trackBy(), i = items()
-        return i.map((item, index) => block(`for:${tb(item, index, i)}`, template, {item,index,array: i}))
+        if (i.length == 0) return [block('for:empty', () => alt, null)]
+        return i.map((item, index) => block(`for:item(${tb(item, index, i)})`, template, {item,index,array: i}))
     })
 }

--- a/src/internal/core/index.ts
+++ b/src/internal/core/index.ts
@@ -97,7 +97,7 @@ export function each<TItem>(
         trackBy?: Accessor<(item: TItem, index: number, array: TItem[]) => any>,
     },
     renderItems: (item: Accessor<TItem>, index: Accessor<number>, array: Accessor<TItem[]>) => Render,
-    alt: Render
+    alt: Render = f()
 ): Render {
     const template = (context: () => {item: TItem, index: number, array: TItem[]}) => renderItems(
         () => context().item,

--- a/src/internal/shared/types.ts
+++ b/src/internal/shared/types.ts
@@ -50,6 +50,8 @@ export type Middleware<Props extends Record<string, any>, T> = (ctx: MiddlewareC
 
 export type Component<Props extends Record<string, any>> = (use: <T>(m: Middleware<Props, T>) => T) => Render
 
+export type Block = <T>(block: <Context>(id: string, template: (context: Accessor<Context>) => Render, context: Context) => T) => T
+
 /**
  * A render instruction used for CSR or SSR.
  */
@@ -62,10 +64,5 @@ export type Render = <T>(render: {
         props: Accessor<Props>
     ): T,
     fragment(children: Render[]): T,
-    when(cond: Accessor, then: Render, alt: Render): T,
-    each<TItem>(
-        items: Accessor<TItem[]>,
-        trackBy: Accessor<(item: TItem, index: number, array: TItem[]) => any>,
-        renderItem: (item: Accessor<TItem>, index: Accessor<number>, array: Accessor<TItem[]>) => Render
-    ): T,
+    directive(blocks: Accessor<Block[]>): T,
 }) => T


### PR DESCRIPTION
These changes decouple the control flow API from the renderer API and modify the `each` function.